### PR TITLE
76/fix/email

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     // AWS S3
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.603'
 

--- a/demo/src/main/java/com/example/demo/config/RedisConfig.java
+++ b/demo/src/main/java/com/example/demo/config/RedisConfig.java
@@ -1,0 +1,15 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/demo/src/main/java/com/example/demo/login/email/util/EmailSenderUtil.java
+++ b/demo/src/main/java/com/example/demo/login/email/util/EmailSenderUtil.java
@@ -1,39 +1,58 @@
 package com.example.demo.login.email.util;
 
 import com.example.demo.login.email.domain.EmailCode;
-
 import com.example.demo.login.email.infrastruture.EmailForm;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
 
 import java.io.UnsupportedEncodingException;
+import java.time.Duration;
 
 @Component
 @RequiredArgsConstructor
 public class EmailSenderUtil {
 
     private final JavaMailSender emailSender;
-
     private final EmailCode emailCode;
     private final EmailForm form;
+    private final StringRedisTemplate redisTemplate;
 
-    public String sendEmail(String toEmail, HttpSession session) throws MessagingException, UnsupportedEncodingException {
-        return getString(toEmail, session);
-    }
+    private static final long AUTH_CODE_TTL_MINUTES = 5;
+    private static final long VERIFIED_FLAG_TTL_MINUTES = 10;
 
-    private String getString(final String toEmail, final HttpSession session) throws MessagingException, UnsupportedEncodingException {
+    public String sendEmail(String toEmail) throws MessagingException, UnsupportedEncodingException {
         String authNum = emailCode.createCode();
-        session.setAttribute(toEmail, authNum);
+        redisTemplate.opsForValue().set(toEmail, authNum, Duration.ofMinutes(AUTH_CODE_TTL_MINUTES));
         MimeMessage emailForm = form.createEmailForm(toEmail, authNum);
         emailSender.send(emailForm);
         return authNum;
     }
 
+    public boolean verifyAuthCode(String email, String inputCode) {
+        String storedCode = redisTemplate.opsForValue().get(email);
+        if (inputCode.equals(storedCode)) {
+            redisTemplate.delete(email); // 인증번호 삭제
+            redisTemplate.opsForValue().set(getVerifiedKey(email), "true", Duration.ofMinutes(VERIFIED_FLAG_TTL_MINUTES));
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isEmailVerified(String email) {
+        return "true".equals(redisTemplate.opsForValue().get(getVerifiedKey(email)));
+    }
+
+    public void clearVerifiedFlag(String email) {
+        redisTemplate.delete(getVerifiedKey(email));
+    }
+
+    private String getVerifiedKey(String email) {
+        return "auth:verified:" + email;
+    }
 }

--- a/demo/src/main/java/com/example/demo/login/global/exception/exceptions/CustomErrorCode.java
+++ b/demo/src/main/java/com/example/demo/login/global/exception/exceptions/CustomErrorCode.java
@@ -9,8 +9,6 @@ public enum CustomErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "T002", "토큰 시간이 만료됐습니다."),
     CART_ITEM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CART_001","이미 장바구니에 담긴 상품입니다."),
     CART_NOT_FOUND_ITEM(HttpStatus.BAD_REQUEST,"CART_OO2","장바구니 아이템이 없습니다.");
-
-
     private final HttpStatus httpStatus;
     private final String customCode;
     private final String message;

--- a/demo/src/main/java/com/example/demo/login/member/exception/exceptions/MemberErrorCode.java
+++ b/demo/src/main/java/com/example/demo/login/member/exception/exceptions/MemberErrorCode.java
@@ -16,7 +16,8 @@ public enum MemberErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A008", "비밀번호는 10자리 이상이어야 합니다."),
     INVALID_SPECIAL_PASSWORD(HttpStatus.BAD_REQUEST, "A009", "비밀번호에는 영문자와 특수문자가 포함되어야 합니다."),
 
-    NOT_FOUND_TOKEN_INFORMATION(HttpStatus.NOT_FOUND, "T001", "토큰 정보를 찾을 수 없습니다.");
+    NOT_FOUND_TOKEN_INFORMATION(HttpStatus.NOT_FOUND, "T001", "토큰 정보를 찾을 수 없습니다."),
+    AUTHENTICATE_EMAIL_FIRST(HttpStatus.FORBIDDEN,"E_001", "먼저 이메일 인증을 완료해주세요.");
 
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/demo/src/main/java/com/example/demo/login/member/exception/exceptions/auth/AuthenticateEmailFirstException.java
+++ b/demo/src/main/java/com/example/demo/login/member/exception/exceptions/auth/AuthenticateEmailFirstException.java
@@ -1,0 +1,11 @@
+package com.example.demo.login.member.exception.exceptions.auth;
+
+import com.example.demo.login.member.exception.exceptions.MemberErrorCode;
+import com.example.demo.login.member.exception.exceptions.MemberException;
+
+public class AuthenticateEmailFirstException extends MemberException {
+
+    public AuthenticateEmailFirstException() {
+        super(MemberErrorCode.AUTHENTICATE_EMAIL_FIRST);
+    }
+}


### PR DESCRIPTION
📌 Redis 기반 이메일 인증 로직 적용

기존에는 이메일 인증번호를 HttpSession에 저장하여 인증 검증을 수행했으나, 이 방식은 서버 간 세션 공유가 불가능해 확장성에 제약이 있었습니다.

이번 PR에서는 인증번호 및 인증 완료 여부를 Redis에 저장하도록 구조를 개선하였습니다.

✅ 주요 변경 사항
- 인증번호 발송 시 Redis에 코드 저장 (TTL 5분)
- 인증번호 검증 성공 시 Redis에 인증 완료 플래그 저장 (TTL 10분)
- 비밀번호 변경 시 인증 완료 플래그를 Redis에서 조회하여 인증 여부 확인
- 인증 성공 시 인증번호 및 플래그 삭제 (1회성 인증 보장)

💡 기대 효과
- Stateless 구조로 서버 확장 및 분산 환경 대응
- 세션 기반 인증 한계 해소 (로드밸런싱 환경 대응)
- 인증 정보 TTL 관리로 보안성과 유지 편의성 강화
- 추후 인증 실패 횟수 제한 등 확장 가능성 고려한 Redis 키 설계 적용

👉 향후 인증 실패 횟수 제한, 인증 재요청 rate-limit 도 Redis 키 활용으로 손쉽게 확장 가능