### PR TITLE
Clean code

### DIFF
--- a/demo/src/main/java/com/example/demo/admin/notice/domain/repository/NoticeRepository.java
+++ b/demo/src/main/java/com/example/demo/admin/notice/domain/repository/NoticeRepository.java
@@ -1,6 +1,5 @@
 package com.example.demo.admin.notice.domain.repository;
 
-
 import com.example.demo.admin.notice.domain.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/demo/src/main/java/com/example/demo/config/CorsCustomFilter.java
+++ b/demo/src/main/java/com/example/demo/config/CorsCustomFilter.java
@@ -14,11 +14,13 @@ public class CorsCustomFilter extends OncePerRequestFilter {
     protected void doFilterInternal(final HttpServletRequest request,
                                     final HttpServletResponse response,
                                     final FilterChain filterChain) throws ServletException, IOException {
-        response.setHeader("Access-Control-Allow-Origin", "*");
+
+        response.setHeader("Access-Control-Allow-Origin", "https://daemyungdesk.com");
         response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
         response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
         response.setHeader("Access-Control-Allow-Credentials", "true");
         response.setHeader("Access-Control-Max-Age", "3600");
+
         filterChain.doFilter(request, response);
     }
 }

--- a/demo/src/main/java/com/example/demo/config/JwtCookieFilter.java
+++ b/demo/src/main/java/com/example/demo/config/JwtCookieFilter.java
@@ -1,0 +1,57 @@
+package com.example.demo.config;
+
+import com.example.demo.login.member.infrastructure.auth.JwtTokenProvider;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class JwtCookieFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtCookieFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = extractTokenFromCookie(request);
+
+        if (token != null) {
+            try {
+                DecodedJWT jwt = jwtTokenProvider.verifyToken(token);
+                Long memberId = jwt.getClaim("memberId").asLong();
+
+                request.setAttribute("memberId", memberId);
+
+            } catch (Exception e) {
+
+                System.out.println("Invalid JWT: " + e.getMessage());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/demo/src/main/java/com/example/demo/config/SameSiteCookieFilter.java
+++ b/demo/src/main/java/com/example/demo/config/SameSiteCookieFilter.java
@@ -1,0 +1,40 @@
+package com.example.demo.config;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collection;
+
+@Component
+public class SameSiteCookieFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        chain.doFilter(request, response);
+
+        if (response instanceof HttpServletResponse res) {
+            Collection<String> headers = res.getHeaders("Set-Cookie");
+            boolean first = true;
+            for (String header : headers) {
+                // 이미 SameSite 설정이 있으면 중복 방지
+                if (header.toLowerCase().contains("samesite")) continue;
+
+                String updatedHeader = header + "; SameSite=None";
+                if (first) {
+                    res.setHeader("Set-Cookie", updatedHeader);
+                    first = false;
+                } else {
+                    res.addHeader("Set-Cookie", updatedHeader);
+                }
+            }
+        }
+    }
+}

--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -3,19 +3,26 @@ package com.example.demo.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
+import com.example.demo.login.member.infrastructure.auth.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().permitAll()
-                );
+                )
+                .addFilterBefore(new JwtCookieFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/demo/src/main/java/com/example/demo/info/controller/certificate/CertificateController.java
+++ b/demo/src/main/java/com/example/demo/info/controller/certificate/CertificateController.java
@@ -26,7 +26,6 @@ public class CertificateController {
         this.certificateService = certificateService;
     }
 
-    // 사진 업로드 (id는 서버에서 자동 생성)
     @PostMapping("/upload")
     public ResponseEntity<CertificateImage> uploadCertificate(@RequestParam("file") MultipartFile file,
                                                               @RequestParam("tag") String tag,

--- a/demo/src/main/java/com/example/demo/login/global/exception/exceptions/CustomErrorCode.java
+++ b/demo/src/main/java/com/example/demo/login/global/exception/exceptions/CustomErrorCode.java
@@ -8,6 +8,7 @@ public enum CustomErrorCode {
     NOT_FIND_TOKEN(HttpStatus.UNAUTHORIZED, "T001", "토큰을 찾을 수 없습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "T002", "토큰 시간이 만료됐습니다."),
     CART_ITEM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CART_001","이미 장바구니에 담긴 상품입니다."),
+    NOT_FOUND_DETAIL(HttpStatus.BAD_REQUEST,"DETAIL_001", "상세 정보가 없습니다."),
     CART_NOT_FOUND_ITEM(HttpStatus.BAD_REQUEST,"CART_OO2","장바구니 아이템이 없습니다.");
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/demo/src/main/java/com/example/demo/login/global/exception/exceptions/NotFoundDetail.java
+++ b/demo/src/main/java/com/example/demo/login/global/exception/exceptions/NotFoundDetail.java
@@ -1,0 +1,7 @@
+package com.example.demo.login.global.exception.exceptions;
+
+public class NotFoundDetail extends CustomException{
+    public NotFoundDetail() {
+        super(CustomErrorCode.NOT_FOUND_DETAIL);
+    }
+}

--- a/demo/src/main/java/com/example/demo/login/member/controller/auth/AuthController.java
+++ b/demo/src/main/java/com/example/demo/login/member/controller/auth/AuthController.java
@@ -12,6 +12,8 @@ import com.example.demo.login.member.service.auth.AuthService;
 
 import com.example.demo.login.util.CorporationValidator;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -57,8 +59,19 @@ public class AuthController {
     }
 
     @PostMapping(value = "/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
-        return ResponseEntity.ok(authService.login(loginRequest));
+    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest, HttpServletResponse response) {
+        LoginResponse loginResponse = authService.login(loginRequest);
+
+        Cookie jwtCookie = new Cookie("token", loginResponse.token());
+        jwtCookie.setHttpOnly(true);
+        jwtCookie.setPath("/");
+        jwtCookie.setMaxAge(60 * 60);
+         jwtCookie.setSecure(true);
+         jwtCookie.setDomain(".daemyungdesk.com");
+
+        response.addCookie(jwtCookie);
+
+        return ResponseEntity.ok().body("로그인 성공 (JWT 쿠키 저장됨)");
     }
 
     @PostMapping("/validate-corporation")

--- a/demo/src/main/java/com/example/demo/login/member/exception/exceptions/MemberErrorCode.java
+++ b/demo/src/main/java/com/example/demo/login/member/exception/exceptions/MemberErrorCode.java
@@ -15,7 +15,7 @@ public enum MemberErrorCode {
     INVALID_LOGIN_REQUEST(HttpStatus.BAD_REQUEST, "A007", "잘못된 로그인 입력입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "A008", "비밀번호는 10자리 이상이어야 합니다."),
     INVALID_SPECIAL_PASSWORD(HttpStatus.BAD_REQUEST, "A009", "비밀번호에는 영문자와 특수문자가 포함되어야 합니다."),
-
+    NOT_FOUND_MEMBER_ID(HttpStatus.BAD_REQUEST,"M001", "회원 정보를 찾을수 없습니다."),
     NOT_FOUND_TOKEN_INFORMATION(HttpStatus.NOT_FOUND, "T001", "토큰 정보를 찾을 수 없습니다."),
     AUTHENTICATE_EMAIL_FIRST(HttpStatus.FORBIDDEN,"E_001", "먼저 이메일 인증을 완료해주세요.");
 

--- a/demo/src/main/java/com/example/demo/login/member/exception/exceptions/auth/NotFoundMemberId.java
+++ b/demo/src/main/java/com/example/demo/login/member/exception/exceptions/auth/NotFoundMemberId.java
@@ -3,9 +3,8 @@ package com.example.demo.login.member.exception.exceptions.auth;
 import com.example.demo.login.member.exception.exceptions.MemberErrorCode;
 import com.example.demo.login.member.exception.exceptions.MemberException;
 
-public class NotFoundMemberByEmailException extends MemberException {
-
-    public NotFoundMemberByEmailException() {
-        super(MemberErrorCode.NOT_FOUND_MEMBER_BY_EMAIL);
+public class NotFoundMemberId extends MemberException {
+    public NotFoundMemberId() {
+        super(MemberErrorCode.NOT_FOUND_MEMBER_ID);
     }
 }

--- a/demo/src/main/java/com/example/demo/login/member/mapper/auth/AuthMapper.java
+++ b/demo/src/main/java/com/example/demo/login/member/mapper/auth/AuthMapper.java
@@ -27,7 +27,7 @@ public class AuthMapper {
         return Member.builder()
                 .memberEmail(request.memberEmail())
                 .memberName(request.memberName())
-                .memberPassword(encodedPassword)  // 수정
+                .memberPassword(encodedPassword)
                 .memberNickName(request.memberNickName())
                 .roadAddress(request.roadAddress())
                 .jibunAddress(request.jibunAddress())

--- a/demo/src/main/java/com/example/demo/mypage/carItem/service/CartService.java
+++ b/demo/src/main/java/com/example/demo/mypage/carItem/service/CartService.java
@@ -1,7 +1,7 @@
 package com.example.demo.mypage.carItem.service;
 
-import com.example.demo.common.exception.CartItemAlreadyExistsException;
 import com.example.demo.common.exception.CartItemNotFoundException;
+import com.example.demo.login.global.exception.exceptions.NotFoundDetail;
 import com.example.demo.login.member.domain.member.Member;
 
 import com.example.demo.login.util.MemberValidator;
@@ -26,7 +26,7 @@ public class CartService {
 
     public void addToCart(Long productDetailId, int quantity, Long memberId) {
         ProductDetail detail = productDetailRepository.findById(productDetailId)
-                .orElseThrow(() -> new IllegalArgumentException("상세 정보 없음"));
+                .orElseThrow(NotFoundDetail::new);
 
         Member member = memberValidator.getMember(memberId);
 

--- a/demo/src/main/java/com/example/demo/mypage/order/service/OrderService.java
+++ b/demo/src/main/java/com/example/demo/mypage/order/service/OrderService.java
@@ -1,6 +1,8 @@
 package com.example.demo.mypage.order.service;
 
 import com.example.demo.login.member.domain.member.Member;
+import com.example.demo.login.member.exception.exceptions.MemberErrorCode;
+import com.example.demo.login.member.exception.exceptions.auth.NotFoundMemberId;
 import com.example.demo.login.member.infrastructure.auth.JwtTokenProvider;
 import com.example.demo.login.member.infrastructure.member.MemberJpaRepository;
 import com.example.demo.mypage.order.controller.dto.OrderRequestDTO;
@@ -29,7 +31,7 @@ public class OrderService {
     public void createOrder(OrderRequestDTO dto, String token) {
         Long memberId = jwtTokenProvider.verifyToken(token).getClaim("memberId").asLong();
         Member member = memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("회원 정보를 찾을 수 없습니다."));
+                .orElseThrow(NotFoundMemberId::new);
 
         Order order = Order.builder()
                 .orderId(dto.getOrderId())

--- a/demo/src/main/java/com/example/demo/product/service/product/ProductLikeService.java
+++ b/demo/src/main/java/com/example/demo/product/service/product/ProductLikeService.java
@@ -20,7 +20,6 @@ public class ProductLikeService {
 
     public boolean toggleLike(Long memberId, Product product) {
         Member member = memberValidator.getMember(memberId);
-
         return toggleFunction(product, member);
     }
 

--- a/demo/src/main/java/com/example/demo/product/service/product/ProductService.java
+++ b/demo/src/main/java/com/example/demo/product/service/product/ProductService.java
@@ -43,7 +43,7 @@ public class ProductService {
         Category category = getCategory(request);
         Result result = new Result(product, category);
 
-        String imageUrl = s3Uploader.uploadFile(imageFile); // 이미지 다시 업로드
+        String imageUrl = s3Uploader.uploadFile(imageFile);
 
         Product updated = getProduct(Product.builder()
                 .id(result.product().getId()), request, result.category(), imageUrl);


### PR DESCRIPTION
✅ 1. JWT 쿠키 인증 구조 전환
	•	기존 Header 인증 방식에서 쿠키 기반 JWT 인증 방식으로 전환
	•	로그인 시 JWT를 token 쿠키에 저장 (HttpOnly + Secure + SameSite=None 설정 포함)
	•	쿠키를 통해 사용자 인증 정보 자동 주입되도록 구성

✅ 2. @Member ArgumentResolver 수정
	•	Authorization 헤더에서 JWT 추출 → ❌
	•	HttpServletRequest에서 쿠키로부터 JWT 추출하도록 ArgumentResolver 코드 수정 → ✅

✅ 3. SameSiteCookieFilter 추가
	•	Set-Cookie 응답 헤더에 SameSite=None 자동으로 붙이기 위한 필터 작성
	•	Secure 환경에서 크로스도메인 쿠키 허용 목적

✅ 4. 로그인 컨트롤러 쿠키 설정 수정
	•	쿠키 옵션에 다음 항목 적용:
	•	HttpOnly = true
	•	Secure = true (SameSite=None을 위해 필수)
	•	SameSite=None (필터에서 적용됨)
	•	Domain = .daemyungdesk.com (하위 도메인 공유 목적)

✅ 5. CORS 설정 보완
	•	WebMvcConfig에서 CORS 설정에 allowCredentials(true) 및 allowedOrigins 명시
	•	http://localhost:3000
	•	https://daemyungdesk.com


✅ 6. Clean Code Focus 
	• 클린 코드를 위한 개행 삭제 
	• SRP 어긋나는 부분들 수정 및 삭제 
	